### PR TITLE
Refactor config loaders and domain core structure

### DIFF
--- a/.run/Main.run.xml
+++ b/.run/Main.run.xml
@@ -6,7 +6,7 @@
     <option name="VM_PARAMETERS" value="-Xmx15m -XX:+UseSerialGC" />
     <extension name="coverage">
       <pattern>
-        <option name="PATTERN" value="com.roomelephant.elephlink.domain.*" />
+        <option name="PATTERN" value="com.roomelephant.elephlink.*" />
         <option name="ENABLED" value="true" />
       </pattern>
     </extension>

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@ if [ -n "${JAVA_OPTS}" ]; then
   echo "Using JAVA_OPTS: $JAVA_OPTS"
 fi
 
-exec java ${JAVA_OPTS} -jar /app/elephlink/app.jar \
+exec java -XX:+UseSerialGC ${JAVA_OPTS} -jar /app/elephlink/app.jar \
   --auth-file=/config/auth.yml \
   --dns-records-file=/config/dns-records.yml \
   --ip-service-file=/config/ip-services.yml

--- a/src/main/java/com/roomelephant/elephlink/Main.java
+++ b/src/main/java/com/roomelephant/elephlink/Main.java
@@ -7,17 +7,17 @@ import static com.roomelephant.elephlink.infra.config.ConfigurationProperties.RE
 import com.roomelephant.elephlink.adapters.cloudflare.CloudFlareServiceImpl;
 import com.roomelephant.elephlink.adapters.ipservice.IpServiceImpl;
 import com.roomelephant.elephlink.domain.CloudFlareService;
-import com.roomelephant.elephlink.domain.Elephlink;
+import com.roomelephant.elephlink.domain.Core;
 import com.roomelephant.elephlink.domain.IpService;
 import com.roomelephant.elephlink.domain.TaskManager;
 import com.roomelephant.elephlink.domain.model.AuthConfig;
 import com.roomelephant.elephlink.domain.model.DnsRecordsConfig;
 import com.roomelephant.elephlink.domain.model.IpServiceConfig;
 import com.roomelephant.elephlink.infra.TaskManagerImpl;
-import com.roomelephant.elephlink.infra.config.ConfigLoader;
-import com.roomelephant.elephlink.infra.config.auth.AuthConfigurationLoader;
-import com.roomelephant.elephlink.infra.config.dnsrecords.RecordsConfigurationLoader;
-import com.roomelephant.elephlink.infra.config.ipservice.IpServiceConfigurationLoader;
+import com.roomelephant.elephlink.infra.ConfigLoader;
+import com.roomelephant.elephlink.infra.config.loaders.AuthConfigurationLoader;
+import com.roomelephant.elephlink.infra.config.loaders.RecordsConfigurationLoader;
+import com.roomelephant.elephlink.infra.config.loaders.IpServiceConfigurationLoader;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.function.Function;
@@ -30,7 +30,7 @@ public class Main {
     log.info("Starting Elephlink ...");
     Map<String, String> parameters = parser.apply(args);
 
-    Elephlink elephlink;
+    Core core;
     try {
       ConfigLoader<AuthConfig> authLoader = new AuthConfigurationLoader();
       AuthConfig authConfig = authLoader.load(parameters.get(AUTH_CONFIGURATION_FILE.key()));
@@ -44,7 +44,7 @@ public class Main {
       IpServiceConfig ipConfig = ipServicesLoader.load(parameters.get(IP_LIST_CONFIGURATION_FILE.key()));
       IpService ipServiceImpl = new IpServiceImpl(ipConfig);
 
-      elephlink = new Elephlink(dnsRecordsConfig, cloudFlareServiceImpl, ipServiceImpl, taskManager);
+      core = new Core(dnsRecordsConfig, cloudFlareServiceImpl, ipServiceImpl, taskManager);
     } catch (Exception e) {
       log.error("Validate your configuration. {}", e.getMessage());
       System.exit(1);
@@ -52,13 +52,13 @@ public class Main {
     }
 
     try {
-      elephlink.validateConfigurations();
+      core.validateConfigurations();
     } catch (Exception e) {
       log.error("Invalid configuration. {}", e.getMessage());
       System.exit(1);
       return;
     }
-    elephlink.start();
+    core.start();
   }
 
   private static final Function<String[], Map<String, String>> parser = parameters -> Arrays.stream(parameters)

--- a/src/main/java/com/roomelephant/elephlink/domain/Core.java
+++ b/src/main/java/com/roomelephant/elephlink/domain/Core.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class Elephlink {
+public class Core {
   private final DnsRecordsConfig dnsRecordsConfig;
   private final CloudFlareService cloudFlareService;
   private final IpService ipService;
@@ -14,8 +14,8 @@ public class Elephlink {
   private final LocalCache cache = LocalCache.getInstance();
 
 
-  public Elephlink(DnsRecordsConfig dnsRecordsConfig, CloudFlareService cloudFlareService, IpService ipService,
-                   TaskManager taskManager) {
+  public Core(DnsRecordsConfig dnsRecordsConfig, CloudFlareService cloudFlareService, IpService ipService,
+              TaskManager taskManager) {
     this.dnsRecordsConfig = dnsRecordsConfig;
     this.cloudFlareService = cloudFlareService;
     this.ipService = ipService;

--- a/src/main/java/com/roomelephant/elephlink/infra/ConfigLoader.java
+++ b/src/main/java/com/roomelephant/elephlink/infra/ConfigLoader.java
@@ -1,4 +1,4 @@
-package com.roomelephant.elephlink.infra.config;
+package com.roomelephant.elephlink.infra;
 
 /**
  * Generic interface for loading configuration files.

--- a/src/main/java/com/roomelephant/elephlink/infra/config/loaders/AuthConfigurationLoader.java
+++ b/src/main/java/com/roomelephant/elephlink/infra/config/loaders/AuthConfigurationLoader.java
@@ -1,13 +1,11 @@
-package com.roomelephant.elephlink.infra.config.auth;
+package com.roomelephant.elephlink.infra.config.loaders;
 
 import static com.roomelephant.elephlink.infra.config.ConfigurationFiles.AUTH_FILE;
-import static com.roomelephant.elephlink.infra.config.auth.AuthConfigurationLoader.AuthProperties.AUTH_EMAIL;
-import static com.roomelephant.elephlink.infra.config.auth.AuthConfigurationLoader.AuthProperties.AUTH_KEY;
-import static com.roomelephant.elephlink.infra.config.auth.AuthConfigurationLoader.AuthProperties.AUTH_METHOD;
-import static com.roomelephant.elephlink.infra.config.auth.AuthConfigurationLoader.AuthProperties.ZONE_IDENTIFIER;
+import static com.roomelephant.elephlink.infra.config.loaders.AuthConfigurationLoader.AuthProperties.AUTH_EMAIL;
+import static com.roomelephant.elephlink.infra.config.loaders.AuthConfigurationLoader.AuthProperties.AUTH_KEY;
+import static com.roomelephant.elephlink.infra.config.loaders.AuthConfigurationLoader.AuthProperties.ZONE_IDENTIFIER;
 
 import com.roomelephant.elephlink.domain.model.AuthConfig;
-import com.roomelephant.elephlink.infra.config.BaseConfigurationLoader;
 import java.util.Map;
 
 public class AuthConfigurationLoader extends BaseConfigurationLoader<AuthConfig> {
@@ -15,28 +13,14 @@ public class AuthConfigurationLoader extends BaseConfigurationLoader<AuthConfig>
   @Override
   protected AuthConfig convert(Map<String, Object> ymlConfig) {
     String email = getAndValidateString(ymlConfig, AUTH_EMAIL.key());
-    AuthConfig.Method method = getAndValidateEnumMethod(ymlConfig);
     String key = getAndValidateString(ymlConfig, AUTH_KEY.key());
     String zoneIdentifier = getAndValidateString(ymlConfig, ZONE_IDENTIFIER.key());
 
     return AuthConfig.builder()
         .email(email)
-        .method(method)
         .key(key)
         .zoneIdentifier(zoneIdentifier)
         .build();
-  }
-
-  private AuthConfig.Method getAndValidateEnumMethod(Map<String, Object> ymlConfig) {
-    String methodRaw = getAndValidateString(ymlConfig, AUTH_METHOD.key());
-    AuthConfig.Method method;
-    try {
-      method = AuthConfig.Method.fromString(methodRaw);
-    } catch (Exception e) {
-      throw new IllegalArgumentException(
-          "Invalid auth configuration. " + methodRaw + " is not recognized. Use 'token' or 'global'.");
-    }
-    return method;
   }
 
   @Override
@@ -54,7 +38,6 @@ public class AuthConfigurationLoader extends BaseConfigurationLoader<AuthConfig>
 
   enum AuthProperties {
     AUTH_EMAIL("email"),
-    AUTH_METHOD("method"),
     AUTH_KEY("key"),
     ZONE_IDENTIFIER("zoneIdentifier");
 

--- a/src/main/java/com/roomelephant/elephlink/infra/config/loaders/BaseConfigurationLoader.java
+++ b/src/main/java/com/roomelephant/elephlink/infra/config/loaders/BaseConfigurationLoader.java
@@ -1,5 +1,6 @@
-package com.roomelephant.elephlink.infra.config;
+package com.roomelephant.elephlink.infra.config.loaders;
 
+import com.roomelephant.elephlink.infra.ConfigLoader;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -8,7 +9,7 @@ import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public abstract class BaseConfigurationLoader<T> implements ConfigLoader<T> {
+abstract class BaseConfigurationLoader<T> implements ConfigLoader<T> {
   private final YmlParser ymlLoader;
 
   protected BaseConfigurationLoader() {

--- a/src/main/java/com/roomelephant/elephlink/infra/config/loaders/IpServiceConfigurationLoader.java
+++ b/src/main/java/com/roomelephant/elephlink/infra/config/loaders/IpServiceConfigurationLoader.java
@@ -1,10 +1,11 @@
-package com.roomelephant.elephlink.infra.config.ipservice;
+package com.roomelephant.elephlink.infra.config.loaders;
 
 import static com.roomelephant.elephlink.infra.config.ConfigurationFiles.IP_SERVICES_FILE;
-import static com.roomelephant.elephlink.infra.config.ipservice.IpServiceConfigurationLoader.IpServicesProperties.IP_SERVICES;
+import static com.roomelephant.elephlink.infra.config.loaders.IpServiceConfigurationLoader.IpServicesProperties.IP_SERVICES;
+import static com.roomelephant.elephlink.infra.config.loaders.IpServiceConfigurationLoader.IpServicesProperties.TIMEOUT;
 
 import com.roomelephant.elephlink.domain.model.IpServiceConfig;
-import com.roomelephant.elephlink.infra.config.BaseConfigurationLoader;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
@@ -13,6 +14,14 @@ public class IpServiceConfigurationLoader extends BaseConfigurationLoader<IpServ
   @Override
   protected IpServiceConfig convert(Map<String, Object> ymlConfig) {
     Object o = ymlConfig.get(IP_SERVICES.key());
+    Long timeoutRaw = null;
+    try {
+      timeoutRaw = Long.valueOf((Integer) ymlConfig.get(TIMEOUT.key()));
+    } catch (Exception e) {
+      timeoutRaw = 1000L;
+
+    }
+    Duration timeout = Duration.ofMillis(timeoutRaw);
 
     List<String> list = switch (o) {
       case List<?> casted -> castToListString(casted);
@@ -24,6 +33,7 @@ public class IpServiceConfigurationLoader extends BaseConfigurationLoader<IpServ
 
     return IpServiceConfig.builder()
         .services(list)
+        .timeout(timeout)
         .build();
 
   }
@@ -34,7 +44,9 @@ public class IpServiceConfigurationLoader extends BaseConfigurationLoader<IpServ
   }
 
   public enum IpServicesProperties {
-    IP_SERVICES("services");
+    IP_SERVICES("services"),
+    TIMEOUT("timeout-in-milliseconds"),
+    ;
 
     private final String key;
 

--- a/src/main/java/com/roomelephant/elephlink/infra/config/loaders/RecordsConfigurationLoader.java
+++ b/src/main/java/com/roomelephant/elephlink/infra/config/loaders/RecordsConfigurationLoader.java
@@ -1,11 +1,10 @@
-package com.roomelephant.elephlink.infra.config.dnsrecords;
+package com.roomelephant.elephlink.infra.config.loaders;
 
 import static com.roomelephant.elephlink.infra.config.ConfigurationFiles.DNS_RECORDS_FILE;
-import static com.roomelephant.elephlink.infra.config.dnsrecords.RecordsConfigurationLoader.RecordProperties.CRON;
-import static com.roomelephant.elephlink.infra.config.dnsrecords.RecordsConfigurationLoader.RecordProperties.RECORDS;
+import static com.roomelephant.elephlink.infra.config.loaders.RecordsConfigurationLoader.RecordProperties.CRON;
+import static com.roomelephant.elephlink.infra.config.loaders.RecordsConfigurationLoader.RecordProperties.RECORDS;
 
 import com.roomelephant.elephlink.domain.model.DnsRecordsConfig;
-import com.roomelephant.elephlink.infra.config.BaseConfigurationLoader;
 import java.util.List;
 import java.util.Map;
 

--- a/src/main/java/com/roomelephant/elephlink/infra/config/loaders/YmlParser.java
+++ b/src/main/java/com/roomelephant/elephlink/infra/config/loaders/YmlParser.java
@@ -1,4 +1,4 @@
-package com.roomelephant.elephlink.infra.config;
+package com.roomelephant.elephlink.infra.config.loaders;
 
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -10,10 +10,10 @@ import org.snakeyaml.engine.v2.api.Load;
 import org.snakeyaml.engine.v2.api.LoadSettings;
 
 @Slf4j
-public class YmlParser {
+class YmlParser {
 
   @SuppressWarnings("unchecked")
-  public Map<String, Object> parse(String fileName) {
+  Map<String, Object> parse(String fileName) {
     try (FileInputStream fis = new FileInputStream(Path.of(fileName).toFile())) {
       LoadSettings settings = LoadSettings.builder().build();
       Load load = new Load(settings);


### PR DESCRIPTION
Renamed Elephlink to Core in the domain layer and moved configuration loader classes to a unified 'infra/config/loaders' package. Updated imports and usages throughout the codebase to reflect these changes.