### PR TITLE
Add configurable timeout for IP service requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ your Internet Service Provider assigns you a dynamic IP address.
 - **Effortless**: Runs on a schedule to automatically detect IP changes and update your DNS records in seconds.
 - **Flexible**: Supports multiple domains, configurable IP detection services and cron-based scheduling.
 - **Secure**: Works with modern Cloudflare API tokens for granular, secure access.
-- **Footprint**: Low footprint on your system, around 10 Mb of RAM.
+- **Footprint**: Low footprint on your system.
 
 ## 🚀 Features
 
@@ -123,6 +123,8 @@ ip-services:
   - https://api.ipify.org
   - https://icanhazip.com
   - https://ipinfo.io/ip
+# Timeout for requesting external ip
+timeout-in-milliseconds: 1000 # default 1000 milliseconds
 ```
 
 ### Running Java

--- a/src/main/java/com/roomelephant/elephlink/adapters/SharedHttpClient.java
+++ b/src/main/java/com/roomelephant/elephlink/adapters/SharedHttpClient.java
@@ -1,0 +1,13 @@
+package com.roomelephant.elephlink.adapters;
+
+import java.net.http.HttpClient;
+import lombok.Getter;
+
+public class SharedHttpClient {
+  @Getter
+  private static final HttpClient client = HttpClient.newHttpClient();
+
+  private SharedHttpClient() {
+  }
+
+}

--- a/src/main/java/com/roomelephant/elephlink/domain/model/IpServiceConfig.java
+++ b/src/main/java/com/roomelephant/elephlink/domain/model/IpServiceConfig.java
@@ -1,10 +1,12 @@
 package com.roomelephant.elephlink.domain.model;
 
+import java.time.Duration;
 import java.util.List;
 import lombok.Builder;
 
 @Builder
 public record IpServiceConfig(
-    List<String> services
+    List<String> services,
+    Duration timeout
 ) {
 }

--- a/src/main/resources/ip-services.yml
+++ b/src/main/resources/ip-services.yml
@@ -2,3 +2,4 @@ services:
   - https://api.ipify.org
   - https://ipv4.icanhazip.com
   - https://ipinfo.io/ip
+timeout-in-milliseconds: 1000


### PR DESCRIPTION
Introduces a timeout setting for external IP service requests, configurable via ip-services.yml. Refactors HTTP client usage to a shared singleton and improves error handling for timeouts and interruptions.