### PR TITLE
Add configurable timeout for DNS record updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ docker run \
   --name elephlink \
   --restart unless-stopped \
   -v /path/to/config/dir/:/config \
-  -e JAVA_OPTS=-Xmx15m -XX:+UseSerialGC \
+  -e JAVA_OPTS=-Xmx15m \
   roomelephant/elephlink:latest
 ```
 
@@ -97,7 +97,9 @@ records:
   - another.yourdomain.com
 # UNIX Cron Expression for the update schedule.
 # This example runs every day at 04:00 AM
-cron-expression: "0 4 * * *" 
+cron-expression: "0 4 * * *"
+# Timeout for requesting external ip
+timeout-in-milliseconds: 3000 # default 1000 milliseconds
 ```
 
 A quick guide to cron expressions:

--- a/src/main/java/com/roomelephant/elephlink/Main.java
+++ b/src/main/java/com/roomelephant/elephlink/Main.java
@@ -5,19 +5,19 @@ import static com.roomelephant.elephlink.infra.config.ConfigurationProperties.IP
 import static com.roomelephant.elephlink.infra.config.ConfigurationProperties.RECORDS_CONFIGURATION_FILE;
 
 import com.roomelephant.elephlink.adapters.cloudflare.CloudFlareService;
+import com.roomelephant.elephlink.adapters.cloudflare.config.CloudflareConfig;
 import com.roomelephant.elephlink.adapters.ipservice.IpServiceImpl;
-import com.roomelephant.elephlink.domain.DnsService;
 import com.roomelephant.elephlink.domain.Core;
+import com.roomelephant.elephlink.domain.DnsService;
 import com.roomelephant.elephlink.domain.IpService;
 import com.roomelephant.elephlink.domain.TaskManager;
-import com.roomelephant.elephlink.adapters.cloudflare.CloudflareConfig;
 import com.roomelephant.elephlink.domain.model.DnsRecordsConfig;
 import com.roomelephant.elephlink.domain.model.IpServiceConfig;
-import com.roomelephant.elephlink.infra.TaskManagerImpl;
 import com.roomelephant.elephlink.infra.ConfigLoader;
+import com.roomelephant.elephlink.infra.TaskManagerImpl;
 import com.roomelephant.elephlink.infra.config.loaders.CloudflareConfigurationLoader;
-import com.roomelephant.elephlink.infra.config.loaders.RecordsConfigurationLoader;
 import com.roomelephant.elephlink.infra.config.loaders.IpServiceConfigurationLoader;
+import com.roomelephant.elephlink.infra.config.loaders.RecordsConfigurationLoader;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.function.Function;
@@ -32,13 +32,13 @@ public class Main {
 
     Core core;
     try {
-      ConfigLoader<CloudflareConfig> cloudflareLoader = new CloudflareConfigurationLoader();
-      CloudflareConfig cloudflareConfig = cloudflareLoader.load(parameters.get(CLOUDFLARE_CONFIGURATION_FILE.key()));
-      DnsService dnsService = new CloudFlareService(cloudflareConfig);
-
       ConfigLoader<DnsRecordsConfig> dnsRecordsLoader = new RecordsConfigurationLoader();
       DnsRecordsConfig dnsRecordsConfig = dnsRecordsLoader.load(parameters.get(RECORDS_CONFIGURATION_FILE.key()));
       TaskManager taskManager = new TaskManagerImpl(dnsRecordsConfig);
+
+      ConfigLoader<CloudflareConfig> cloudflareLoader = new CloudflareConfigurationLoader();
+      CloudflareConfig cloudflareConfig = cloudflareLoader.load(parameters.get(CLOUDFLARE_CONFIGURATION_FILE.key()));
+      DnsService dnsService = new CloudFlareService(cloudflareConfig, dnsRecordsConfig.timeout());
 
       ConfigLoader<IpServiceConfig> ipServicesLoader = new IpServiceConfigurationLoader();
       IpServiceConfig ipConfig = ipServicesLoader.load(parameters.get(IP_LIST_CONFIGURATION_FILE.key()));

--- a/src/main/java/com/roomelephant/elephlink/adapters/cloudflare/CfRequest.java
+++ b/src/main/java/com/roomelephant/elephlink/adapters/cloudflare/CfRequest.java
@@ -7,6 +7,7 @@ import com.roomelephant.elephlink.domain.model.RequestFailedException;
 import java.net.URI;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.time.Duration;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 
@@ -14,6 +15,12 @@ import lombok.extern.slf4j.Slf4j;
 class CfRequest {
   private static final String BASE_URL = "https://api.cloudflare.com/client/v4";
   private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  private final Duration timeout;
+
+  CfRequest(Duration timeout) {
+    this.timeout = timeout;
+  }
 
   <T> T get(String url, Map<String, String> headers, Class<T> clazz) {
     HttpRequest.Builder builder = HttpRequest.newBuilder()
@@ -40,6 +47,7 @@ class CfRequest {
     HttpRequest request = builder
         .uri(URI.create(BASE_URL + url))
         .header("Accept", "application/json")
+        .timeout(timeout)
         .build();
 
     HttpResponse<String> response;

--- a/src/main/java/com/roomelephant/elephlink/adapters/cloudflare/CloudFlareService.java
+++ b/src/main/java/com/roomelephant/elephlink/adapters/cloudflare/CloudFlareService.java
@@ -3,16 +3,16 @@ package com.roomelephant.elephlink.adapters.cloudflare;
 import static com.roomelephant.elephlink.adapters.cloudflare.DnsRecordsResponse.DnsRecordType.A;
 import static com.roomelephant.elephlink.adapters.cloudflare.TokenVerifyResponse.Status.ACTIVE;
 
+import com.roomelephant.elephlink.adapters.cloudflare.config.CloudflareConfig;
 import com.roomelephant.elephlink.domain.DnsService;
 import com.roomelephant.elephlink.domain.model.DnsRecord;
+import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class CloudFlareService implements DnsService {
-  private static final CfRequest client = new CfRequest();
-
   private static final String TOKEN_VALIDATION_URL = "/user/tokens/verify";
   private static final String LIST_RECORDS = "/zones/%s/dns_records?type=%s&name=%s";
   private static final String UPDATE_RECORDS = "/zones/%s/dns_records/%s";
@@ -21,9 +21,11 @@ public class CloudFlareService implements DnsService {
   private static final String X_AUTH_EMAIL = "X-Auth-Email";
 
   private final CloudflareConfig cloudflareConfig;
+  private final CfRequest client;
 
-  public CloudFlareService(CloudflareConfig cloudflareConfig) {
+  public CloudFlareService(CloudflareConfig cloudflareConfig, Duration timeout) {
     this.cloudflareConfig = cloudflareConfig;
+    this.client = new CfRequest(timeout);
   }
 
   @Override

--- a/src/main/java/com/roomelephant/elephlink/adapters/cloudflare/config/CloudflareConfig.java
+++ b/src/main/java/com/roomelephant/elephlink/adapters/cloudflare/config/CloudflareConfig.java
@@ -1,4 +1,4 @@
-package com.roomelephant.elephlink.adapters.cloudflare;
+package com.roomelephant.elephlink.adapters.cloudflare.config;
 
 import lombok.Builder;
 

--- a/src/main/java/com/roomelephant/elephlink/domain/Core.java
+++ b/src/main/java/com/roomelephant/elephlink/domain/Core.java
@@ -8,16 +8,16 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class Core {
   private final DnsRecordsConfig dnsRecordsConfig;
-  private final DnsService DNSService;
+  private final DnsService dnsService;
   private final IpService ipService;
   private final TaskManager taskManager;
   private final LocalCache cache = LocalCache.getInstance();
 
 
-  public Core(DnsRecordsConfig dnsRecordsConfig, DnsService DNSService, IpService ipService,
+  public Core(DnsRecordsConfig dnsRecordsConfig, DnsService dnsService, IpService ipService,
               TaskManager taskManager) {
     this.dnsRecordsConfig = dnsRecordsConfig;
-    this.DNSService = DNSService;
+    this.dnsService = dnsService;
     this.ipService = ipService;
     this.taskManager = taskManager;
   }
@@ -35,13 +35,13 @@ public class Core {
   }
 
   private void initializeCloudflare() {
-    boolean validToken = DNSService.isValidToken();
+    boolean validToken = dnsService.isValidToken();
     if (!validToken) {
       throw new IllegalArgumentException("Cloudflare token is not valid.");
     }
 
     for (String dnsRecord : dnsRecordsConfig.records()) {
-      Optional<DnsRecord> cfDnsRecord = DNSService.getDnsRecord(dnsRecord);
+      Optional<DnsRecord> cfDnsRecord = dnsService.getDnsRecord(dnsRecord);
       if (cfDnsRecord.isEmpty()) {
         throw new IllegalArgumentException("Record '" + dnsRecord
             + "' does not exist. Please create one first. "
@@ -96,7 +96,7 @@ public class Core {
 
       dnsRecord.setContent(currentIp);
       try {
-        boolean result = DNSService.updateRecord(dnsRecord);
+        boolean result = dnsService.updateRecord(dnsRecord);
         if (result) {
           log.info("Successfully updated cloudflare record '{}' to use ip {} instead of {}.", dnsRecord.getName(),
               currentIp, previousIp);

--- a/src/main/java/com/roomelephant/elephlink/domain/model/DnsRecordsConfig.java
+++ b/src/main/java/com/roomelephant/elephlink/domain/model/DnsRecordsConfig.java
@@ -1,11 +1,13 @@
 package com.roomelephant.elephlink.domain.model;
 
+import java.time.Duration;
 import java.util.List;
 import lombok.Builder;
 
 @Builder
 public record DnsRecordsConfig(
     List<String> records,
-    String cronExpression
+    String cronExpression,
+    Duration timeout
 ) {
 }

--- a/src/main/java/com/roomelephant/elephlink/infra/config/loaders/BaseConfigurationLoader.java
+++ b/src/main/java/com/roomelephant/elephlink/infra/config/loaders/BaseConfigurationLoader.java
@@ -4,6 +4,7 @@ import com.roomelephant.elephlink.infra.ConfigLoader;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -53,5 +54,16 @@ abstract class BaseConfigurationLoader<T> implements ConfigLoader<T> {
         .filter(String.class::isInstance)
         .map(String.class::cast)
         .toList();
+  }
+
+  protected static Duration getDuration(Map<String, Object> ymlConfig, String key) {
+    Long timeoutRaw = null;
+    try {
+      timeoutRaw = Long.valueOf((Integer) ymlConfig.get(key));
+    } catch (Exception e) {
+      timeoutRaw = 1000L;
+
+    }
+    return Duration.ofMillis(timeoutRaw);
   }
 }

--- a/src/main/java/com/roomelephant/elephlink/infra/config/loaders/CloudflareConfigurationLoader.java
+++ b/src/main/java/com/roomelephant/elephlink/infra/config/loaders/CloudflareConfigurationLoader.java
@@ -5,7 +5,7 @@ import static com.roomelephant.elephlink.infra.config.loaders.CloudflareConfigur
 import static com.roomelephant.elephlink.infra.config.loaders.CloudflareConfigurationLoader.CloudflareProperties.KEY;
 import static com.roomelephant.elephlink.infra.config.loaders.CloudflareConfigurationLoader.CloudflareProperties.ZONE_IDENTIFIER;
 
-import com.roomelephant.elephlink.adapters.cloudflare.CloudflareConfig;
+import com.roomelephant.elephlink.adapters.cloudflare.config.CloudflareConfig;
 import java.util.Map;
 
 public class CloudflareConfigurationLoader extends BaseConfigurationLoader<CloudflareConfig> {

--- a/src/main/java/com/roomelephant/elephlink/infra/config/loaders/IpServiceConfigurationLoader.java
+++ b/src/main/java/com/roomelephant/elephlink/infra/config/loaders/IpServiceConfigurationLoader.java
@@ -14,14 +14,7 @@ public class IpServiceConfigurationLoader extends BaseConfigurationLoader<IpServ
   @Override
   protected IpServiceConfig convert(Map<String, Object> ymlConfig) {
     Object o = ymlConfig.get(IP_SERVICES.key());
-    Long timeoutRaw = null;
-    try {
-      timeoutRaw = Long.valueOf((Integer) ymlConfig.get(TIMEOUT.key()));
-    } catch (Exception e) {
-      timeoutRaw = 1000L;
-
-    }
-    Duration timeout = Duration.ofMillis(timeoutRaw);
+    Duration timeout = getDuration(ymlConfig, TIMEOUT.key());
 
     List<String> list = switch (o) {
       case List<?> casted -> castToListString(casted);

--- a/src/main/java/com/roomelephant/elephlink/infra/config/loaders/RecordsConfigurationLoader.java
+++ b/src/main/java/com/roomelephant/elephlink/infra/config/loaders/RecordsConfigurationLoader.java
@@ -3,6 +3,7 @@ package com.roomelephant.elephlink.infra.config.loaders;
 import static com.roomelephant.elephlink.infra.config.ConfigurationFiles.DNS_RECORDS_FILE;
 import static com.roomelephant.elephlink.infra.config.loaders.RecordsConfigurationLoader.RecordProperties.CRON;
 import static com.roomelephant.elephlink.infra.config.loaders.RecordsConfigurationLoader.RecordProperties.RECORDS;
+import static com.roomelephant.elephlink.infra.config.loaders.RecordsConfigurationLoader.RecordProperties.TIMEOUT;
 
 import com.roomelephant.elephlink.domain.model.DnsRecordsConfig;
 import java.util.List;
@@ -24,6 +25,7 @@ public class RecordsConfigurationLoader extends BaseConfigurationLoader<DnsRecor
     return DnsRecordsConfig.builder()
         .records(list)
         .cronExpression(getAndValidateString(ymlConfig, CRON.key()))
+        .timeout(getDuration(ymlConfig, TIMEOUT.key()))
         .build();
 
   }
@@ -43,7 +45,8 @@ public class RecordsConfigurationLoader extends BaseConfigurationLoader<DnsRecor
 
   public enum RecordProperties {
     RECORDS("records"),
-    CRON("cron-expression");
+    CRON("cron-expression"),
+    TIMEOUT("timeout-in-milliseconds");
 
     private final String key;
 

--- a/src/main/resources/dns-records.yml
+++ b/src/main/resources/dns-records.yml
@@ -1,4 +1,4 @@
 records:
-  - roomelephant.com
-cron-expression: "* * * * *" # UNIX Cron Expression
-timeout-in-milliseconds: 1000
+  - domain.com
+cron-expression: "0 4 * * *" # UNIX Cron Expression
+timeout-in-milliseconds: 3000


### PR DESCRIPTION
Introduces a 'timeout-in-milliseconds' option to DNS records configuration, allowing users to specify request timeouts for Cloudflare API calls. Refactors related classes to support the new timeout setting, updates configuration loaders, and adjusts documentation and example config accordingly.